### PR TITLE
Fix management group discovery

### DIFF
--- a/scripts/DeleteCustomPolicies.ps1
+++ b/scripts/DeleteCustomPolicies.ps1
@@ -43,7 +43,8 @@
 
 # Function to get all management groups
 function Get-AllManagementGroups {
-    $managementGroups = Get-AzManagementGroup
+    # Retrieve all management groups, including nested groups
+    $managementGroups = Get-AzManagementGroup -Recurse
     return $managementGroups
 }
 


### PR DESCRIPTION
## Summary
- ensure `DeleteCustomPolicies.ps1` retrieves all management groups recursively

## Testing
- `terraform init -backend=false` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685336b4ca30832194778a93b5c7e8c3